### PR TITLE
Replace import of “src.pycomposefile” in a test

### DIFF
--- a/src/tests/service/test_service_environment.py
+++ b/src/tests/service/test_service_environment.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from src.pycomposefile import compose_file
+from pycomposefile import compose_file
 
 from ..compose_generator import ComposeGenerator
 


### PR DESCRIPTION
This was odd, and seems to be unnecessary.