### PR TITLE
fix: error when the environment variable value contains =

### DIFF
--- a/sample/test.env
+++ b/sample/test.env
@@ -1,3 +1,4 @@
 # Set Rails/Rack environment
 RACK_ENV=development
 VAR="quoted"
+SOME_VAR="value with equals=sign"

--- a/src/pycomposefile/compose_element/compose_list_or_map.py
+++ b/src/pycomposefile/compose_element/compose_list_or_map.py
@@ -15,7 +15,7 @@ class ComposeListOrMapElement(ComposeDataTypeTransformer, dict):
             value = None
             key = source_string.rstrip("=")
         else:
-            key, value = source_string.split("=")
+            key, value = source_string.split("=", 1)
         self[key] = value
 
     def evaluate_from_list(self, source_list):

--- a/src/tests/service/test_service_environment_file.py
+++ b/src/tests/service/test_service_environment_file.py
@@ -11,6 +11,7 @@ class TestComposeServiceEnvironmentFile(unittest.TestCase):
         self.assertEqual(compose_file.services["frontend"].env_file[0], "./sample/test.env")
         self.assertEqual(environment_from_file["RACK_ENV"], "development")
         self.assertEqual(environment_from_file["VAR"], '"quoted"')
+        self.assertEqual(environment_from_file["SOME_VAR"], '"value with equals=sign"')
 
     def test_service_with_list_environment_file(self):
         compose_file = ComposeGenerator.get_compose_with_environment_file_list()


### PR DESCRIPTION
An error occurred when the environment variable value contained =, so this has been fixed.