### PR TITLE
Update service

### DIFF
--- a/src/pycomposefile/service/service.py
+++ b/src/pycomposefile/service/service.py
@@ -138,7 +138,7 @@ class Service(ComposeElement):
     def resolve_environment_hierarchy(self):
         if self.env_file is not None:
             env_file = self.env_file.readFile()
-            env_file.update(self.environment)
+            env_file.update(self.environment or [])
             return env_file
         else:
             return self.environment


### PR DESCRIPTION
Makes it so if there isn't an environment section in the compose file it doesn't fail. 

```The command failed with an unexpected error. Here is the traceback:
'NoneType' object is not iterable
Traceback (most recent call last):
  File "/opt/az/lib/python3.12/site-packages/knack/cli.py", line 233, in invoke
    cmd_result = self.invocation.execute(args)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 666, in execute
    raise ex
  File "/opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 734, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 703, in _run_job
    result = cmd_copy(params)
             ^^^^^^^^^^^^^^^^
  File "/opt/az/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 336, in __call__
    return self.handler(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/az/lib/python3.12/site-packages/azure/cli/core/commands/command_operation.py", line 120, in handler
    return op(**command_args)
           ^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.azure/cliextensions/containerapp/azext_containerapp/custom.py", line 1478, in create_containerapps_from_compose
    environment = resolve_environment_from_service(service)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/az/lib/python3.12/site-packages/azure/cli/command_modules/containerapp/_compose_utils.py", line 217, in resolve_environment_from_service
    env_vars = service.resolve_environment_hierarchy()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/az/lib/python3.12/site-packages/pycomposefile/service/service.py", line 141, in resolve_environment_hierarchy
    env_file.update(self.environment)
TypeError: 'NoneType' object is not iterable```